### PR TITLE
Refactor superuser checks

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -66,9 +66,7 @@ func SystemMetricsHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to access system metrics without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "superuser privileges required for this operation"})
+	if !requireSuperuser(c, username, "access system metrics") {
 		return
 	}
 

--- a/internal/api/ssh_handlers.go
+++ b/internal/api/ssh_handlers.go
@@ -196,9 +196,9 @@ func ListSSHSessionsHandler(c *gin.Context) {
 
 	// Only allow superusers to see all sessions
 	if showAllSessions && !userIsSuperuser {
-		log.Warnf("User '%s' attempted to list all SSH sessions without superuser privileges", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required to list all SSH sessions"})
-		return
+		if !requireSuperuser(c, username, "list all SSH sessions") {
+			return
+		}
 	}
 
 	// When calling ListSessions:

--- a/internal/api/tools_handlers.go
+++ b/internal/api/tools_handlers.go
@@ -38,9 +38,7 @@ func DisableTxOffloadHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use disable-tx-offload without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use disable-tx-offload") {
 		return
 	}
 
@@ -105,9 +103,7 @@ func CreateCAHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use cert ca create without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use cert ca create") {
 		return
 	}
 
@@ -269,9 +265,7 @@ func SignCertHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use cert sign without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use cert sign") {
 		return
 	}
 
@@ -700,9 +694,7 @@ func CreateVethHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use veth create without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use veth create") {
 		return
 	}
 
@@ -781,9 +773,7 @@ func CreateVxlanHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use vxlan create without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use vxlan create") {
 		return
 	}
 
@@ -878,9 +868,7 @@ func DeleteVxlanHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// --- Authorization: Superuser Only ---
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to use vxlan delete without superuser privileges.", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation."})
+	if !requireSuperuser(c, username, "use vxlan delete") {
 		return
 	}
 

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -27,9 +27,7 @@ func ListUsersHandler(c *gin.Context) {
 	username := c.GetString("username")
 
 	// Only superusers can list all users
-	if !isSuperuser(username) {
-		log.Warnf("User '%s' attempted to list all users without superuser privileges", username)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation"})
+	if !requireSuperuser(c, username, "list all users") {
 		return
 	}
 
@@ -101,9 +99,7 @@ func CreateUserHandler(c *gin.Context) {
 	requestingUser := c.GetString("username")
 
 	// Only superusers can create users
-	if !isSuperuser(requestingUser) {
-		log.Warnf("User '%s' attempted to create a user without superuser privileges", requestingUser)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation"})
+	if !requireSuperuser(c, requestingUser, "create a user") {
 		return
 	}
 
@@ -214,9 +210,7 @@ func DeleteUserHandler(c *gin.Context) {
 	targetUser := c.Param("username")
 
 	// Only superusers can delete users
-	if !isSuperuser(requestingUser) {
-		log.Warnf("User '%s' attempted to delete user '%s' without superuser privileges", requestingUser, targetUser)
-		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "Superuser privileges required for this operation"})
+	if !requireSuperuser(c, requestingUser, "delete user '"+targetUser+"'") {
 		return
 	}
 

--- a/tests_go/health_suite_test.go
+++ b/tests_go/health_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,7 +143,7 @@ func (s *HealthSuite) TestMetricsEndpointRegularUser() {
 
 	err = json.Unmarshal(bodyBytes, &errResp)
 	s.Assert().NoError(err, "Failed to unmarshal error response. Body: %s", string(bodyBytes))
-	s.Assert().Contains(errResp.Error, "superuser privileges required", "Error message should indicate superuser privileges are required")
+	s.Assert().Contains(strings.ToLower(errResp.Error), "superuser privileges required", "Error message should indicate superuser privileges are required")
 
 	if statusCode == http.StatusForbidden {
 		s.logSuccess("Correctly received 403 Forbidden when accessing metrics as regular user")

--- a/tests_go/lab_topology_suite_test.go
+++ b/tests_go/lab_topology_suite_test.go
@@ -70,7 +70,7 @@ func (s *LabTopologySuite) TestGenerateTopology() {
 	jsonPayload := s.mustMarshal(generateRequest)
 
 	generateURL := fmt.Sprintf("%s/api/v1/generate", s.cfg.APIURL)
-	bodyBytes, statusCode, err := s.doRequest("POST", generateURL, userHeaders, bytes.NewBuffer(jsonPayload), s.cfg.RequestTimeout)
+	bodyBytes, statusCode, err := s.doRequest("POST", generateURL, userHeaders, bytes.NewBuffer(jsonPayload), s.cfg.DeployTimeout)
 	s.Require().NoError(err, "Failed to execute generate topology request")
 	s.Require().Equal(http.StatusOK, statusCode, "Expected status 200 generating topology for '%s'. Body: %s", generatedLabName, string(bodyBytes))
 


### PR DESCRIPTION
## Summary
- add `requireSuperuser` helper
- use new helper in various API handlers

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24 (running go 1.23.8; GOTOOLCHAIN=local))*